### PR TITLE
add optional input for npm tag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,5 +38,5 @@ jobs:
           # use an eventually loop as NPM's query doesn't seem to update immediately
           while [[ "$version" != "0.0.${{ github.run_number }}" ]]
           do
-            version=$(curl https://registry.npmjs.org/@cucumber/test-release-automation | jq -r '."dist-tags".a-special-tag')
+            version=$(curl https://registry.npmjs.org/@cucumber/test-release-automation | jq -r '."dist-tags"."a-special-tag"')
           done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
-          cache: 'npm'
+          node-version: "16"
+          cache: "npm"
           cache-dependency-path: javascript/package-lock.json
       - name: Set unique package version
         id: set-version
@@ -29,6 +29,7 @@ jobs:
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           working-directory: "javascript"
+          npm-tag: a-special-tag
       - name: Assert that latest published package version is as expected
         timeout-minutes: 1
         run: |
@@ -36,5 +37,5 @@ jobs:
           # use an eventually loop as NPM's query doesn't seem to update immediately
           while [[ "$version" != "0.0.${{ github.run_number }}" ]]
           do
-            version=$(curl https://registry.npmjs.org/@cucumber/test-release-automation | jq -r '."dist-tags".latest')
+            version=$(curl https://registry.npmjs.org/@cucumber/test-release-automation | jq -r '."dist-tags".a-special-tag')
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add optional input for `npm-tag`
 
 ## [v1.0.0] - 2021-09-21
 ### Added

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ inputs:
   npm-token: 
     description: "Authentication token to use when publishing to NPM"
     required: true
+  npm-tag:
+    description: "Tag to attach to the published version, see https://docs.npmjs.com/cli/v8/commands/npm-publish#tag"
+    required: false
+    default: "latest"
   working-directory:
     description: "Path within the repo to the folder where the package.json file lives"
     required: false
@@ -20,7 +24,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
     - name: publish package
       run: |
-        npm publish --access public
+        npm publish --access public --tag ${{ inputs.npm-tag }}
       env:
         NPM_TOKEN: ${{ inputs.npm-token }}
       shell: bash


### PR DESCRIPTION
# Description

Adds an optional input `npm-tag` that's mapped through to the `--tag` argument on the `npm publish` command.

This means that from the consuming project workflow we'll be able to specify the tag if doing a release candidate or similar.

# Motivation & context

See https://cucumberbdd.slack.com/archives/C6QJ6N695/p1643518577526019

TLDR: We need to be able to specify `--tag next` when doing a release candidate so regular users still get the latest stable when they do `npm install <package>`.

## Type of change

<!--- Delete any options that are not relevant -->

- New feature (non-breaking change which adds new behaviour)

# Checklist:

<!--- 
Go over all the following points, and put an `x` in all the boxes that apply. 
-->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
