### PR TITLE
fix: replace ::set-output with new pattern

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
         run: |
           version=0.0.$GITHUB_RUN_NUMBER
           npm version $version
-          echo "::set-output name=version::$version"
           echo "version=$version" >> $GITHUB_OUTPUT
         working-directory: "test"
       - name: Test the action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
           version=0.0.$GITHUB_RUN_NUMBER
           npm version $version
           echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
         working-directory: "test"
       - name: Test the action
         uses: ./


### PR DESCRIPTION
### 🤔 What's changed?

Replace use of `::set-output` with new suggested pattern, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### ⚡️ What's your motivation? 

Helps towards https://github.com/cucumber/common/issues/2150.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
